### PR TITLE
Add .keep file and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,10 @@ bower.json
 ## Rails engine
 spec/dummy/log
 spec/dummy/log
-spec/dummy/tmp
+spec/dummy/tmp/*
+!/spec/dummy/tmp/cache/
+/spec/dummy/tmp/cache/*
+!/spec/dummy/tmp/cache/.keep
 spec/dummy/db/*.sqlite3
 spec/dummy/public/system
 spec/dummy/coverage/


### PR DESCRIPTION
I can't execute `rspec` after `git clone` and `bundle install`, because `/spec/dummy/tmp/cache` directory doesn't exist. :crying_cat_face: 

```
nekova@nekova ~/dev/nyauth [master *]
☁🚀 ☁ › bundle exec rspec                                                  

Finished in 0.00027 seconds (files took 2.89 seconds to load)
0 examples, 0 failures

/Users/nekova/dev/nyauth/vendor/bundle/ruby/2.2.0/gems/activesupport-4.2.0/lib/active_support/cache/file_store.rb:30:in `open':
No such file or directory @ dir_initialize - /Users/nekova/dev/nyauth/spec/dummy/tmp/cache/ (Errno::ENOENT)
```

I found similar problem in [stack overflow](http://stackoverflow.com/a/30008984/4743547), 
so I added `.keep` file to the directory and updated `.gitignore` :octocat:
