### PR TITLE
Fix current authenticated for signed-in user

### DIFF
--- a/app/controllers/nyauth/passwords_controller.rb
+++ b/app/controllers/nyauth/passwords_controller.rb
@@ -15,7 +15,7 @@ module Nyauth
     private
 
     def set_client
-      @client = nyauth_client_class.find(current_authenticated.id)
+      @client = nyauth_client_class.find(current_authenticated(as: nyauth_client_name).id)
     end
 
     def client_params


### PR DESCRIPTION
I passed a value current_authenticated method in password controller, otherwise the current_authenticated returns nil, except that nyauth_client_name is user.
