### PR TITLE
Add parent controller configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ nyauth.configure do |config|
   config.confirmation_expire_limit = 1.hour
   config.reset_password_expire_limit = 1.hour
   config.mail_delivery_method = :deliver_now
+  config.parent_controller = "ApplicationController"
   config.redirect_path do |urls|
     # config.redirect_path_after_sign_in = -> (client_name) {
     #  if client_name == :admin

--- a/app/controllers/nyauth/base_controller.rb
+++ b/app/controllers/nyauth/base_controller.rb
@@ -1,5 +1,5 @@
 module Nyauth
-  class BaseController < ApplicationController
+  class BaseController < Nyauth.configuration.parent_controller.constantize
     include Nyauth::ControllerConcern
     self.responder = Nyauth::AppResponder
     respond_to :html, :json

--- a/lib/generators/nyauth/templates/nyauth_install_initializer.rb
+++ b/lib/generators/nyauth/templates/nyauth_install_initializer.rb
@@ -4,6 +4,7 @@ Nyauth.configure do |config|
   config.reset_password_expire_limit = 1.hour
   config.mail_delivery_method = :deliver_now
   config.use_cookie_auth = false
+  config.parent_controller = "ApplicationController"
   config.redirect_path do |urls|
     # config.redirect_path_after_sign_in = -> (client_name) {
     #  if client_name == :admin

--- a/lib/nyauth/configuration.rb
+++ b/lib/nyauth/configuration.rb
@@ -15,8 +15,8 @@ module Nyauth
                   :password_digest_stretches,
                   :encryption_secret,
                   :mail_delivery_method,
-                  :use_cookie_auth
-
+                  :use_cookie_auth,
+                  :parent_controller
 
     def initialize
       @redirect_path_after_sign_in = Proc.new {}
@@ -35,6 +35,7 @@ module Nyauth
       @mail_delivery_method = :deliver_now
       @use_cookie_auth = false
       @redirect_path_block = Proc.new {}
+      @parent_controller = "ApplicationController"
     end
 
     def redirect_path(&block)

--- a/spec/controllers/nyauth/base_controller_spec.rb
+++ b/spec/controllers/nyauth/base_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Nyauth::BaseController do
+  context 'when nyauth parent_controller is default(=ApplicationController)' do
+    it_behaves_like 'Nyauth::SessionConcern'
+  end
+
+  context 'when nyauth parent_controller is another controller' do
+    before { Nyauth.configuration.parent_controller = 'AnotherApplicationController' }
+
+    it_behaves_like 'Nyauth::SessionConcern'
+  end
+end

--- a/spec/dummy/app/controllers/another_application_controller.rb
+++ b/spec/dummy/app/controllers/another_application_controller.rb
@@ -1,0 +1,4 @@
+class AnotherApplicationController < ActionController::Base
+  include Nyauth::ControllerConcern
+  protect_from_forgery with: :exception
+end


### PR DESCRIPTION
## Summary

This PR provides parent_controller configuration to Nyauth::BaseController like [DeviseControlller](https://github.com/plataformatec/devise/blob/master/app/controllers/devise_controller.rb)
## My work
- [x] Add parent_controller configuration to NyAuth::Configuration
- [x] Add base_controller spec
- [x] modify configuration generator
- [x] modify README
